### PR TITLE
Add refraction to simple renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .pyc
+.vscode
 __pycache__/
 *.egg-info/
 .installed.cfg

--- a/pyrt/material/material.py
+++ b/pyrt/material/material.py
@@ -13,7 +13,7 @@ class Material(object):
 
     """Base Material Class"""
 
-    def __init__(self, color: Vec3 = Vec3(0.,0.,0.), shininess: float = 0.0, reflectivity: float = 0.5, refraction: float = 1.0):
+    def __init__(self, color: Vec3 = Vec3(0.,0.,0.), shininess: float = 0.0, reflectivity: float = 0.5, refraction: float = 1.0, transparency = 0.0):
         self.color = color
         self.shininess = shininess
         self.reflectivity = reflectivity
@@ -28,6 +28,7 @@ class Material(object):
         Also check the "refract3" function in math/vecops.py
         """
         self.refraction = refraction
+        self.transparency = transparency
 
     @abstractmethod
     def shade(self, camera: Camera, ray: Ray, hitrecord: HitRecord,  lights: list) -> Vec3:

--- a/pyrt/material/phongmaterial.py
+++ b/pyrt/material/phongmaterial.py
@@ -12,8 +12,8 @@ class PhongMaterial(Material):
 
     """Base Material Class"""
 
-    def __init__(self, color: Vec3 = Vec3(1.,1.,1.), shininess: float = 10.0, reflectivity: float = 0.0, refraction: float = 1.0):
-        Material.__init__(self, color, shininess, reflectivity, refraction)
+    def __init__(self, color: Vec3 = Vec3(1.,1.,1.), shininess: float = 10.0, reflectivity: float = 0.0, refraction: float = 1.0, transparency = 0.0):
+        Material.__init__(self, color, shininess, reflectivity, refraction, transparency)
 
     def shade(self, camera: Camera, ray: Ray, hitrecord: HitRecord,  lights: list) -> Vec3:
         """

--- a/pyrt/renderer/simplert.py
+++ b/pyrt/renderer/simplert.py
@@ -69,22 +69,39 @@ class SimpleRT(Renderer):
             fs /= 4.
 
         return fs,local_num_shadow_rays
+    
+    def _recurse_shade(self, scene: Scene, ray: Ray, iteration_num: int) -> tuple:
+        hitrecord = HitRecord()
+        hit, r, g, b = self._shade(scene, ray, hitrecord)
 
-    def _reflect(self, r: int, g: int, b: int, scene: Scene, ray: Ray, hitrecord: HitRecord) -> tuple:
-        reflect_ray = Ray(hitrecord.point, reflect3(hitrecord.normal_g, ray.direction))
-        reflect_hitrecord = HitRecord()
+        if not hit or iteration_num == 0:
+            return r, g, b
+        
+        if hitrecord.material.reflectivity != 0.0:
+            reflect_ray = Ray(hitrecord.point, reflect3(hitrecord.normal_g, ray.direction))
+            new_r, new_g, new_b = self._recurse_shade(scene, reflect_ray, iteration_num - 1)
 
-        hit, rnew, gnew, bnew = self._shade(scene, reflect_ray, reflect_hitrecord)
-
-        if hit:
             ref1 = hitrecord.material.reflectivity
             ref2 = 1.-ref1
-            rnew = int ( ref1 * rnew + ref2 * r)
-            gnew = int ( ref1 * gnew + ref2 * g)
-            bnew = int ( ref1 * bnew + ref2 * b)
-            return rnew, gnew, bnew, reflect_ray, reflect_hitrecord
-        else:
-            return r,g,b,None,None
+            r = int ( ref1 * new_r + ref2 * r)
+            g = int ( ref1 * new_g + ref2 * g)
+            b = int ( ref1 * new_b + ref2 * b)
+
+            self.num_secondary_rays += 1
+
+        if hitrecord.material.transparency != 0.0:
+            refract_ray = Ray(hitrecord.point + ray.direction * 0.01, refract3(hitrecord.normal_g, ray.direction, hitrecord.material.refraction))
+            new_r, new_g, new_b = self._recurse_shade(scene, refract_ray, iteration_num - 1)
+
+            ref1 = hitrecord.material.transparency
+            ref2 = 1.-ref1
+            r = int ( ref1 * new_r + ref2 * r)
+            g = int ( ref1 * new_g + ref2 * g)
+            b = int ( ref1 * new_b + ref2 * b)
+
+            self.num_secondary_rays += 1
+        
+        return r, g, b
 
     def render(self, scene: Scene) -> RGBImage:
         if not scene.camera:
@@ -109,17 +126,7 @@ class SimpleRT(Renderer):
                 self.num_rays += 1
 
                 # Primary Ray:
-                hit, r, g, b = self._shade(scene, ray, hitrecord)
-
-                if hit and hitrecord.material.reflectivity != 0.0:
-                    refhit = hitrecord.copy()
-                    refray = ray.copy()
-                    for i in range(self.iterations - 1):
-                        r, g, b, refray, refhit = self._reflect(r,g,b, scene, refray, refhit)
-                        self.num_secondary_rays += 1
-                        if refray is None:
-                            break
-
+                r, g, b = self._recurse_shade(scene, ray, self.iterations - 1)
                 image.drawPixelFast8(x, y, r, g, b)
 
 


### PR DESCRIPTION
**1. What has been done:**
    Make refraction possible for simple renderer

**2. Why we did it:**
PyRT lets one study ray-tracing not only by using and reading the library, but by extending it as well. We've implemented these features as part of our university course to further our understanding of computer graphics.

**3. How we did it:**
A new method '_recurse_shade' was added to SimpleRT class. It performs shading recursively, and considers refractive and
reflective material properties. After each collision, there may be spawned two additional rays:

* reflective ray (if material.reflectivity != 0)
* refractive ray (if material.transparency != 0)

This method also takes recurse depth as argument.